### PR TITLE
fix(frontend-login-registration): error message and remembering email

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -30,7 +30,8 @@
                                 <div class="relative">
                                     <input type="email" id="email" name="email"
                                            class="py-3 px-4 block w-full border border-gray-200 rounded-lg text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:ring-gray-600"
-                                           required>
+                                           required
+                                           value="{{old('email')}}">
                                     @error('email')
                                         <span class="text-red-500">{{ $message }}</span>
                                     @enderror

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -29,7 +29,8 @@
                                 <div class="relative">
                                     <input type="email" id="email" name="email"
                                            class="py-3 px-4 block w-full border border-gray-200 rounded-lg text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:ring-gray-600"
-                                           required>
+                                           required
+                                           value="{{old('email')}}">
                                     @error('email')
                                         <span class="text-red-500">{{ __('auth.' . $message) }}</span>
                                     @enderror
@@ -53,7 +54,7 @@
                                            class="py-3 px-4 block w-full border border-gray-200 rounded-lg text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:ring-gray-600"
                                            required>
                                     @error('password')
-                                        <span class="text-red-500">{{ $message }}</span>
+                                    <span class="text-red-500">{{ __('auth.' . $message) }}</span>
                                     @enderror
                                     <div class="hidden absolute inset-y-0 end-0 pointer-events-none pe-3">
                                         <svg class="size-5 text-red-500" width="16" height="16" fill="currentColor"


### PR DESCRIPTION
The error message did not use localisation and the email disappeared when the user got an error