### PR TITLE
feat(product-edit): addition soft deletes

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -40,6 +40,11 @@ class ProductController extends Controller
             return redirect()->back()->with('error', 'Product not found.');
         }
         $product->name = $validatedData['name'];
+
+        $isInactive = $request->has('inactive') ? 1 : 0;
+
+        $product->inactive = $isInactive;
+
         $product->save();
         return redirect()->route('product.EditProduct', ['id' => $product->id])->with('success', 'Product updated successfully.');
     }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -41,7 +41,7 @@ class ProductController extends Controller
         }
         $product->name = $validatedData['name'];
 
-        $isInactive = $request->has('inactive') ? 1 : 0;
+        $isInactive = $request->has('inactive-checkbox') ? 1 : 0;
 
         $product->inactive = $isInactive;
 

--- a/database/migrations/2024_04_12_154758_products_add_inactive_column.php
+++ b/database/migrations/2024_04_12_154758_products_add_inactive_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->boolean('inactive')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('inactive');
+        });
+    }
+};

--- a/lang/nl/products.php
+++ b/lang/nl/products.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'inactive-product' => 'Zet product op inactief',
+    'active-product' => 'Zet product op actief',
+];

--- a/resources/views/admin/EditProduct.blade.php
+++ b/resources/views/admin/EditProduct.blade.php
@@ -121,10 +121,10 @@
 
                     <div class="flex">
                         @if($product->inactive === 1)
-                            <input name="inactive" type="checkbox" class="shrink-0 mt-0.5 border-gray-200 rounded text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-gray-800 dark:border-gray-700 dark:checked:bg-blue-500 dark:checked:border-blue-500 dark:focus:ring-offset-gray-800" id="hs-default-checkbox" checked>
+                            <input name="inactive-checkbox" type="checkbox" class="shrink-0 mt-0.5 border-gray-200 rounded text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-gray-800 dark:border-gray-700 dark:checked:bg-blue-500 dark:checked:border-blue-500 dark:focus:ring-offset-gray-800" id="hs-default-checkbox" checked>
                             <label for="hs-default-checkbox" class="text-sm text-gray-500 ms-3 dark:text-gray-400">{{ __('products.active-product') }}</label>
                         @else
-                            <input name="inactive" type="checkbox" class="shrink-0 mt-0.5 border-gray-200 rounded text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-gray-800 dark:border-gray-700 dark:checked:bg-blue-500 dark:checked:border-blue-500 dark:focus:ring-offset-gray-800" id="hs-default-checkbox">
+                            <input name="inactive-checkbox" type="checkbox" class="shrink-0 mt-0.5 border-gray-200 rounded text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-gray-800 dark:border-gray-700 dark:checked:bg-blue-500 dark:checked:border-blue-500 dark:focus:ring-offset-gray-800" id="hs-default-checkbox">
                             <label for="hs-default-checkbox" class="text-sm text-gray-500 ms-3 dark:text-gray-400">{{ __('products.inactive-product') }}</label>
                         @endif
                     </div>

--- a/resources/views/admin/EditProduct.blade.php
+++ b/resources/views/admin/EditProduct.blade.php
@@ -118,6 +118,17 @@
                         <textarea name="description" id="product-description" class="form-control" rows="4">{{ $product->description }}</textarea>
 
                     </div>
+
+                    <div class="flex">
+                        @if($product->inactive === 1)
+                            <input name="inactive" type="checkbox" class="shrink-0 mt-0.5 border-gray-200 rounded text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-gray-800 dark:border-gray-700 dark:checked:bg-blue-500 dark:checked:border-blue-500 dark:focus:ring-offset-gray-800" id="hs-default-checkbox" checked>
+                            <label for="hs-default-checkbox" class="text-sm text-gray-500 ms-3 dark:text-gray-400">{{ __('products.active-product') }}</label>
+                        @else
+                            <input name="inactive" type="checkbox" class="shrink-0 mt-0.5 border-gray-200 rounded text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-gray-800 dark:border-gray-700 dark:checked:bg-blue-500 dark:checked:border-blue-500 dark:focus:ring-offset-gray-800" id="hs-default-checkbox">
+                            <label for="hs-default-checkbox" class="text-sm text-gray-500 ms-3 dark:text-gray-400">{{ __('products.inactive-product') }}</label>
+                        @endif
+                    </div>
+
                     <!-- Add Product Button -->
                     <div>
                         <button id="big-screen" type="submit"

--- a/tests/Browser/ProductUpdateTest.php
+++ b/tests/Browser/ProductUpdateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\Product;
+use App\Models\User;
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class ProductUpdateTest extends DuskTestCase
+{
+    /**
+     * A Dusk test example.
+     */
+    public function testMarkProductAsInactive(): void
+    {
+        $admin = User::factory()->create(['email' => 'admin@admin.nl']);
+        $admin->assignRole('admin');
+
+        $this->browse(function (Browser $browser) use ($admin) {
+            $product = Product::create([
+                'name' => 'TestAll',
+                'image_path' => 'https://placehold.co/200x200',
+                'product_type_id' => 3,
+                'description' => 'Dit is een testproduct voor iedereen.',
+            ]);
+
+            $browser->loginAs($admin)
+                ->visit(route('product.EditProduct', ['id' => $product->id]))
+                ->click('#hs-default-checkbox')
+                ->click('#big-screen')
+                ->visit(route('orders.product', ['name' => $product->name]))
+                ->assertDontSee($product->name);
+        });
+    }
+}

--- a/tests/Feature/ProductUpdateTest.php
+++ b/tests/Feature/ProductUpdateTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ProductUpdateTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     */
+    public function test_mark_product_as_inactive(): void
+    {
+        $admin = User::factory()->create(['email' => 'admin@test.com']);
+
+        if (!Role::where('name', 'admin')->exists()) {
+            Role::create(['name' => 'admin']);
+        }
+
+        $admin->assignRole('admin');
+
+        $product = Product::create([
+            'name' => 'TestAll',
+            'image_path' => 'https://placehold.co/200x200',
+            'product_type_id' => 3,
+            'description' => 'Dit is een testproduct voor iedereen.',
+        ]);
+
+        $response = $this->actingAs($admin)->put(route('product.update', ['id' => $product->id]),
+            [
+                'name' => $product->name,
+                'inactive' => 'true'
+            ]
+        );
+
+        $response->assertRedirect(route('product.EditProduct', ['id' => $product->id]))
+            ->assertSessionHas('success', 'Product updated successfully.');
+
+        $updatedProduct = Product::find($product->id);
+
+        $this->assertEquals(1, $updatedProduct->inactive);
+    }
+}


### PR DESCRIPTION
In view de optie toegevoegd om een item op inactief te zetten; deze kan ook weer op actief gezet worden. In de controller code toegevoegd omtrent de inactive state. Ook begin gemaakt met localisatie.

Middels een migratie wordt er een inactive kolom toegevoegd aan products. Voer dan ook weer migrations uit.

Ook heb ik tests geschreven.