### PR TITLE
feat(orderdetails): added new orderdetails view + enum

### DIFF
--- a/app/Enum/DeliveryStatus.php
+++ b/app/Enum/DeliveryStatus.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Enum;
+
+enum DeliveryStatus: string
+{
+    case Cancelled = 'cancelled';
+    case PaymentRefunded = 'payment_refunded';
+    case AwaitingPayment = 'awaiting_payment';
+    case Processing = 'processing';
+    case Delivered = 'delivered';
+    case Finalized = 'finalized';
+
+    public static function localised(): array
+    {
+        return [
+            self::Cancelled->value => __('delivery_status.cancelled'),
+            self::PaymentRefunded->value => __('delivery_status.payment_refunded'),
+            self::AwaitingPayment->value => __('delivery_status.awaiting_payment'),
+            self::Processing->value => __('delivery_status.processing'),
+            self::Delivered->value => __('delivery_status.delivered'),
+            self::Finalized->value => __('delivery_status.finalized'),
+        ];
+    }
+
+    public static function delocalised(string $value): self
+    {
+        return match ($value) {
+            __('delivery_status.cancelled') => self::Cancelled,
+            __('delivery_status.payment_refunded') => self::PaymentRefunded,
+            __('delivery_status.awaiting_payment') => self::AwaitingPayment,
+            __('delivery_status.processing') => self::Processing,
+            __('delivery_status.delivered') => self::Delivered,
+            __('delivery_status.finalized') => self::Finalized,
+        };
+    }
+
+    public static function localisedValue(string $value): string
+    {
+        return match ($value) {
+            self::Cancelled->value => __('delivery_status.cancelled'),
+            self::PaymentRefunded->value => __('delivery_status.payment_refunded'),
+            self::AwaitingPayment->value => __('delivery_status.awaiting_payment'),
+            self::Processing->value => __('delivery_status.processing'),
+            self::Delivered->value => __('delivery_status.delivered'),
+            self::Finalized->value => __('delivery_status.finalized'),
+        };
+    }
+}

--- a/app/Http/Controllers/UserOrdersController.php
+++ b/app/Http/Controllers/UserOrdersController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class UserOrdersController extends Controller
+{
+    public function orderDetails() {
+        return view('orders.orderdetails');
+    }
+}

--- a/lang/nl/delivery_status.php
+++ b/lang/nl/delivery_status.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'cancelled' => 'Geannuleerd',
+    'payment_refunded' => 'Terugbetaald',
+    'awaiting_payment' => 'Wachten op betaling',
+    'processing' => 'In behandeling',
+    'delivered' => 'Geleverd in ruimte',
+    'finalized' => 'Afgerond',
+];

--- a/lang/nl/orders/orders.php
+++ b/lang/nl/orders/orders.php
@@ -43,6 +43,12 @@ return [
     'streetname' => 'Straatnaam',
     'cityName' => 'Plaatsnaam',
 
+    'back-to-orders' => 'Terug naar bestellingen',
+    'cancel-order' => 'Annuleer bestelling',
+    'order-date' => 'Besteldatum',
+    'total-price' => 'Totaalbedrag',
+    'amount-items' => 'stuk(s)',
+
     'form-lid-name-error' => 'Uw lid naam is niet ingevuld.',
     'form-group-error' => 'Deze groep bestaat niet (meer).',
 ];

--- a/lang/nl/orders/orders.php
+++ b/lang/nl/orders/orders.php
@@ -28,6 +28,7 @@ return [
     'order-products' => 'Artikelen',
     'order-total' => 'Totaal',
     'order-to-order' => 'Naar bestellen',
+    'order-details' => 'Order details',
 
     'order-data' => 'Uw gegevens',
     'fill-information' => 'Vul hier je gegevens in.',

--- a/resources/views/orders/orderdetails.blade.php
+++ b/resources/views/orders/orderdetails.blade.php
@@ -8,15 +8,37 @@
 
     <!-- TODO: replace hardcoded string w/ attributes and localization -->
 
+    <div class="text-sm">
+        <a href="#" class="flex flex-row items-center hover:text-blue-600 dark:text-white dark:fill-white">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15 18L9 12L15 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <div>Terug naar bestellingen</div>
+        </a>
+    </div>
+
     <div class="m-4">
-        <div class="flex flex-row justify-between w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
-            <div>Bestelling: 123234</div>
-            <div>Besteldatum: 0001-01-01</div>
+        <div class="flex flex-row justify-between items-center w-full dark:text-white">
+            <div>
+                <div class="text-4xl">Bestelling 123234</div>
+            </div>
+            <div class="flex flex-row justify-center gap-4 items-center">
+                <div>Besteldatum</div>
+                <div class="p-2 border rounded dark:border-gray-700">01-01-0001</div>
+            </div>
+            <div class="flex flex-row justify-center gap-4 items-center">
+                <div>Totaalbedrag</div>
+                <div class="p-2 border rounded dark:border-gray-700">€99,99</div>
+            </div>
             <div>Geannuleerd</div>
         </div>
     </div>
 
-    @for($i = 0; $i < 4; $i++)
+    <div class="m-4">
+        <button class="bg-red-600 text-white rounded p-2 hover:bg-red-900">Annuleer bestelling</button>
+    </div>
+
+    @for($i = 0; $i < 3; $i++)
 
         <div class="m-4">
             <div class="flex flex-row justify-between items-center w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
@@ -24,7 +46,7 @@
                     <img src="https://placehold.co/200" alt="product image">
                 </div>
                 <div>
-                    <a href="#" action="" class="font-bold">
+                    <a href="#" class="font-bold">
                         Product titel
                     </a>
                 </div>
@@ -35,11 +57,5 @@
         </div>
 
     @endfor
-
-    <div class="m-4">
-        <div class="flex flex-row justify-center w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
-            <div>Totaal: €99,99</div>
-        </div>
-    </div>
 
 @endsection

--- a/resources/views/orders/orderdetails.blade.php
+++ b/resources/views/orders/orderdetails.blade.php
@@ -9,8 +9,8 @@
     <!-- TODO: replace hardcoded string w/ attributes and localization -->
 
     <div class="m-4">
-        <div class="flex flex-row justify-between w-full bg-white p-6 rounded-xl">
-            <div>Bestelling 1234</div>
+        <div class="flex flex-row justify-between w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
+            <div>Bestelling: 123234</div>
             <div>Besteldatum: 0001-01-01</div>
             <div>Geannuleerd</div>
         </div>
@@ -19,11 +19,15 @@
     @for($i = 0; $i < 4; $i++)
 
         <div class="m-4">
-            <div class="flex flex-row justify-between items-center w-full bg-white p-6 rounded-xl">
+            <div class="flex flex-row justify-between items-center w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
                 <div>
                     <img src="https://placehold.co/200" alt="product image">
                 </div>
-                <div>Product titel</div>
+                <div>
+                    <a href="#" action="" class="font-bold">
+                        Product titel
+                    </a>
+                </div>
                 <div>M</div>
                 <div>€10,00</div>
                 <div>2 stuks</div>
@@ -33,7 +37,7 @@
     @endfor
 
     <div class="m-4">
-        <div class="flex flex-row justify-center w-full bg-white p-6 rounded-xl">
+        <div class="flex flex-row justify-center w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
             <div>Totaal: €99,99</div>
         </div>
     </div>

--- a/resources/views/orders/orderdetails.blade.php
+++ b/resources/views/orders/orderdetails.blade.php
@@ -17,45 +17,48 @@
         </a>
     </div>
 
-    <div class="m-4">
-        <div class="flex flex-row justify-between items-center w-full dark:text-white">
-            <div>
-                <div class="text-4xl">Bestelling 123234</div>
+    <div class="shadow p-4 m-4 rounded-xl">
+        <div class="m-4">
+            <div class="flex flex-row justify-between items-center w-full dark:text-white">
+                <div>
+                    <div class="text-4xl">Bestelling 123234</div>
+                </div>
+                <div class="flex flex-row justify-center gap-4 items-center">
+                    <div>Besteldatum</div>
+                    <div class="p-2 rounded shadow dark:border dark:border-gray-700">01-04-2024</div>
+                </div>
+                <div class="flex flex-row justify-center gap-4 items-center">
+                    <div>Totaalbedrag</div>
+                    <div class="p-2 rounded shadow dark:border dark:border-gray-700">€60,00</div>
+                </div>
+                <div>Geannuleerd</div>
             </div>
-            <div class="flex flex-row justify-center gap-4 items-center">
-                <div>Besteldatum</div>
-                <div class="p-2 border rounded dark:border-gray-700">01-01-0001</div>
-            </div>
-            <div class="flex flex-row justify-center gap-4 items-center">
-                <div>Totaalbedrag</div>
-                <div class="p-2 border rounded dark:border-gray-700">€99,99</div>
-            </div>
-            <div>Geannuleerd</div>
         </div>
-    </div>
-
-    <div class="m-4">
-        <button class="bg-red-600 text-white rounded p-2 hover:bg-red-900">Annuleer bestelling</button>
-    </div>
-
-    @for($i = 0; $i < 3; $i++)
 
         <div class="m-4">
-            <div class="flex flex-row justify-between items-center w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
-                <div>
-                    <img src="https://placehold.co/200" alt="product image">
-                </div>
-                <div>
-                    <a href="#" class="font-bold">
-                        Product titel
-                    </a>
-                </div>
-                <div>M</div>
-                <div>€10,00</div>
-                <div>2 stuks</div>
-            </div>
+            <button class="bg-red-600 text-white rounded p-2 hover:bg-red-900">Annuleer bestelling</button>
         </div>
 
-    @endfor
+        @for($i = 0; $i < 3; $i++)
+
+            <div class="m-4">
+                <div
+                    class="flex flex-row justify-between items-center w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
+                    <div>
+                        <img src="https://placehold.co/200" alt="product image">
+                    </div>
+                    <div>
+                        <a href="#" class="font-bold">
+                            Product titel
+                        </a>
+                    </div>
+                    <div>M</div>
+                    <div>€10,00</div>
+                    <div>2 stuks</div>
+                </div>
+            </div>
+
+        @endfor
+    </div>
 
 @endsection

--- a/resources/views/orders/orderdetails.blade.php
+++ b/resources/views/orders/orderdetails.blade.php
@@ -44,10 +44,8 @@
 
             <div class="m-4">
                 <div
-                    class="flex flex-row justify-between items-center w-full p-6 rounded-xl border dark:text-white dark:border-gray-700">
-                    <div>
-                        <img src="https://placehold.co/200" alt="product image">
-                    </div>
+                    class="flex flex-row justify-between items-center w-full pr-6 rounded-xl border dark:text-white dark:border-gray-700">
+                    <img src="https://placehold.co/200" alt="product image" class="rounded-l-xl">
                     <div>
                         <a href="#" class="font-bold">
                             Product titel

--- a/resources/views/orders/orderdetails.blade.php
+++ b/resources/views/orders/orderdetails.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.base')
+
+@php
+    $title = __('orders/orders.order-details');
+@endphp
+
+@section('content')
+
+    <!-- TODO: replace hardcoded string w/ attributes and localization -->
+
+    <div class="m-4">
+        <div class="flex flex-row justify-between w-full bg-white p-6 rounded-xl">
+            <div>Bestelling 1234</div>
+            <div>Besteldatum: 0001-01-01</div>
+            <div>Geannuleerd</div>
+        </div>
+    </div>
+
+    @for($i = 0; $i < 4; $i++)
+
+        <div class="m-4">
+            <div class="flex flex-row justify-between items-center w-full bg-white p-6 rounded-xl">
+                <div>
+                    <img src="https://placehold.co/200" alt="product image">
+                </div>
+                <div>Product titel</div>
+                <div>M</div>
+                <div>€10,00</div>
+                <div>2 stuks</div>
+            </div>
+        </div>
+
+    @endfor
+
+    <div class="m-4">
+        <div class="flex flex-row justify-center w-full bg-white p-6 rounded-xl">
+            <div>Totaal: €99,99</div>
+        </div>
+    </div>
+
+@endsection

--- a/resources/views/orders/orderdetails.blade.php
+++ b/resources/views/orders/orderdetails.blade.php
@@ -6,14 +6,14 @@
 
 @section('content')
 
-    <!-- TODO: replace hardcoded string w/ attributes and localization -->
+    <!-- TODO: replace hardcoded string w/ attributes -->
 
     <div class="text-sm">
         <a href="#" class="flex flex-row items-center hover:text-blue-600 dark:text-white dark:fill-white">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M15 18L9 12L15 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <div>Terug naar bestellingen</div>
+            <div>{{ __('orders/orders.back-to-orders') }}</div>
         </a>
     </div>
 
@@ -21,14 +21,14 @@
         <div class="m-4">
             <div class="flex flex-row justify-between items-center w-full dark:text-white">
                 <div>
-                    <div class="text-4xl">Bestelling 123234</div>
+                    <div class="text-4xl">{{ __('orders/orders.order') }} 123234</div>
                 </div>
                 <div class="flex flex-row justify-center gap-4 items-center">
-                    <div>Besteldatum</div>
+                    <div>{{ __('orders/orders.order-date') }}</div>
                     <div class="p-2 rounded shadow dark:border dark:border-gray-700">01-04-2024</div>
                 </div>
                 <div class="flex flex-row justify-center gap-4 items-center">
-                    <div>Totaalbedrag</div>
+                    <div>{{ __('orders/orders.total-price') }}</div>
                     <div class="p-2 rounded shadow dark:border dark:border-gray-700">€60,00</div>
                 </div>
                 <div>Geannuleerd</div>
@@ -36,7 +36,8 @@
         </div>
 
         <div class="m-4">
-            <button class="bg-red-600 text-white rounded p-2 hover:bg-red-900">Annuleer bestelling</button>
+            <button
+                class="bg-red-600 text-white rounded p-2 hover:bg-red-900">{{ __('orders/orders.cancel-order') }}</button>
         </div>
 
         @for($i = 0; $i < 3; $i++)
@@ -54,7 +55,7 @@
                     </div>
                     <div>M</div>
                     <div>€10,00</div>
-                    <div>2 stuks</div>
+                    <div>2 {{ __('orders/orders.amount-items') }}</div>
                 </div>
             </div>
 

--- a/resources/views/orders/orderdetails.blade.php
+++ b/resources/views/orders/orderdetails.blade.php
@@ -19,15 +19,15 @@
 
     <div class="shadow p-4 m-4 rounded-xl">
         <div class="m-4">
-            <div class="flex flex-row justify-between items-center w-full dark:text-white">
-                <div>
+            <div class="flex flex-col gap-4 lg:flex-row justify-between items-center w-full dark:text-white">
+                <div class="mb-2 sm:mb-0">
                     <div class="text-4xl">{{ __('orders/orders.order') }} 123234</div>
                 </div>
-                <div class="flex flex-row justify-center gap-4 items-center">
+                <div class="flex flex-col sm:flex-row justify-center gap-4 items-center">
                     <div>{{ __('orders/orders.order-date') }}</div>
                     <div class="p-2 rounded shadow dark:border dark:border-gray-700">01-04-2024</div>
                 </div>
-                <div class="flex flex-row justify-center gap-4 items-center">
+                <div class="flex flex-col sm:flex-row justify-center gap-4 items-center">
                     <div>{{ __('orders/orders.total-price') }}</div>
                     <div class="p-2 rounded shadow dark:border dark:border-gray-700">€60,00</div>
                 </div>
@@ -35,7 +35,7 @@
             </div>
         </div>
 
-        <div class="m-4">
+        <div class="m-4 flex flex-row justify-center lg:justify-normal items-center">
             <button
                 class="bg-red-600 text-white rounded p-2 hover:bg-red-900">{{ __('orders/orders.cancel-order') }}</button>
         </div>
@@ -43,10 +43,9 @@
         @for($i = 0; $i < 3; $i++)
 
             <div class="m-4">
-                <div
-                    class="flex flex-row justify-between items-center w-full pr-6 rounded-xl border dark:text-white dark:border-gray-700">
-                    <img src="https://placehold.co/200" alt="product image" class="rounded-l-xl">
-                    <div>
+                <div class="flex flex-col gap-1 sm:gap-0 pb-1 sm:pb-0 sm:flex-row justify-between items-center sm:pr-6 rounded-xl border dark:text-white dark:border-gray-700">
+                    <img src="https://placehold.co/200" alt="product image" class="rounded-t-xl sm:rounded-tr-none sm:rounded-l-xl w-full sm:w-fit h-auto">
+                    <div class="">
                         <a href="#" class="font-bold">
                             Product titel
                         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AccountsController;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\ShoppingCartController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\UserOrdersController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\GmailController;
 
@@ -120,8 +121,6 @@ Route::get("/auth/google/callback", [GmailController::class, 'gmailAuthCallback'
 ->name('gmail.auth-callback');
 
 // Order cancelling testing page (remove when orderDetails is made)
-Route::get('/testOrders', [TestController::class, 'cancelOrderTest'])
-    ->name('test.cancelOrderTest');
-Route::post('/testOrders', [TestController::class, 'cancelOrder'])
-    ->name('test.cancel-order');
+Route::get('/orderDetails', [UserOrdersController::class, 'orderDetails'])
+    ->name('orders-user.details-order');
 

--- a/tests/Browser/OrderDetailsTest.php
+++ b/tests/Browser/OrderDetailsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Browser;
+
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class OrderDetailsTest extends DuskTestCase
+{
+    /**
+     * A Dusk test example.
+     */
+    public function test_responsiveness_screenshots(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/orderDetails')
+                ->responsiveScreenshots('orderDetails/orderDetails');
+        });
+    }
+}


### PR DESCRIPTION
Dit is puur de view voor de orderdetails, dus het is nog niet functioneel. Sommige strings zullen daardoor dus ook hardcoded zijn.

Het is responsive en cohesive met de andere pagina's. Het is ook volgens het goedgekeurde ontwerp die staat bij de user story van de bestelling annuleren.

Alhoewel, ik heb zelf wel een knopje toegevoegd om weer terug naar de bestellingen te kunnen gaan.

Verderest is de pagina responsive (test aanwezig) en het heeft dark mode support.

Edit: Ik heb trouwens ook alvast de deliverystatus enum van Linde overgenomen.