### PR TITLE
fix(bestelling): size display fix

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -39,16 +39,9 @@ class OrderController extends Controller
         }
 
         // Get all Products from obtained Group
-        $products = Product::join('product_group', 'products.id', '=', 'product_group.product_id')
-            ->join('groups', 'product_group.group_id', '=', 'groups.id')
-            ->join('product_sizes', 'groups.size_id', '=', 'product_sizes.id')
-            ->join('product_product_size', function ($join) {
-                $join->on('products.id', '=', 'product_product_size.product_id')
-                    ->on('product_sizes.id', '=', 'product_product_size.product_size_id');
-            })
-            ->where('groups.id', '=', $group->id)
-            ->select('products.*', 'product_product_size.*')
-            ->get();
+        $products = Product::whereHas('groups', function ($query) use ($group) {
+            $query->where('groups.id', '=', $group->id);
+        })->get();
 
         return view('orders.overview', [
             'products' => $products,

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Group extends Model
 {
@@ -18,5 +19,9 @@ class Group extends Model
     public function orders(): HasMany
     {
         return $this->hasMany(Product::class);
+    }
+
+    public function size(): HasOne {
+        return $this->hasOne(ProductSize::class, 'id', 'size_id');
     }
 }

--- a/resources/views/orders/product.blade.php
+++ b/resources/views/orders/product.blade.php
@@ -48,7 +48,11 @@
                     <p class="dark:text-white">
                         <span>{{ __('common.currency_symbol') }}</span>
                         <span id="product-price">
-                            {{ number_format($product->productSizes->first()->pivot->price, 2, __('common.seperator'), '.') }}
+                            @if (count($productSizes->where('size', '=', $group->size->size)) === 0)
+                            {{ number_format($productSizes->first()->pivot->price, 2, __('common.seperator'), '.') }}
+                            @else
+                            {{ number_format($productSizes->where('size', '=', $group->size->size)->first()->pivot->price, 2, __('common.seperator'), '.') }}
+                            @endif
                         </span>
                     </p>
                     @if (count($productSizes) === 1)


### PR DESCRIPTION
De size van een product zorgde ervoor dat een product wel of niet op een groep overview staat. Dat is er nu uitgehaald, als een product dan toch geen "preffered" size heeft wordt de eerste beste gepakt. Als een product wel een "preffered" szie heeft wordt die alsnog gepakt.