### PR TITLE
feat(accounts): addition frontend 

### DIFF
--- a/lang/nl/manage-accounts/accounts.php
+++ b/lang/nl/manage-accounts/accounts.php
@@ -16,4 +16,5 @@ return [
     "empty_table" => "Geen accounts gevonden",
     "remove_filters_button" => "Filters verwijderen",
     "filter_error" => "Filteren van accounts mislukt!",
+    "add-role" => "Rol toevoegen",
 ];

--- a/public/js/manage-accounts/addrolebutton.js
+++ b/public/js/manage-accounts/addrolebutton.js
@@ -4,9 +4,16 @@ document.addEventListener('DOMContentLoaded', function () {
     addRoleButtons.forEach(function (button) {
         button.addEventListener('click', function () {
             const parent = button.parentElement;
-            const selectRoleDiv = parent.querySelector('#selectRole-div');
+            const selectRoleContainer = parent.querySelector('#selectRoleContainer');
+            const cancelButton = parent.querySelector('#cancelButton');
 
-            selectRoleDiv.classList.remove('hidden');
+            cancelButton.addEventListener('click', function () {
+                selectRoleContainer.classList.add('hidden');
+                button.classList.remove('hidden');
+            });
+
+            selectRoleContainer.classList.remove('hidden');
+
             button.classList.add('hidden');
         });
     });

--- a/public/js/manage-accounts/addrolebutton.js
+++ b/public/js/manage-accounts/addrolebutton.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const addRoleButtons = document.querySelectorAll('#addRoleButton');
+
+    addRoleButtons.forEach(function (button) {
+        button.addEventListener('click', function () {
+            const parent = button.parentElement;
+            const selectRoleDiv = parent.querySelector('#selectRole-div');
+
+            selectRoleDiv.classList.remove('hidden');
+            button.classList.add('hidden');
+        });
+    });
+});

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -7,6 +7,7 @@
 @push('scripts')
     <script src="{{ asset('js/manage-accounts/accounts.js') }}" defer></script>
     <script src="{{ asset('js/manage-accounts/filter.js') }}" defer></script>
+    <script src="{{ asset('js/manage-accounts/addrolebutton.js') }}" defer></script>
 @endpush
 
 @section('content')
@@ -84,15 +85,14 @@
                                 {{ $account['email'] }}
                             </td>
                             <td class="flex items-center justify-end px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
-                                <!--<div id="role-modal" class="">
-                                    <div id="selectRole-div" class="relative"
-                                         data-account-email="{{ $account->email }}"
-                                         data-old-roles="{{ json_encode($account->roles->pluck('name')) }}"
-                                         style="width: 250px;">
-                                        <label for="selectRole"
-                                               hidden>{{ __('manage-accounts/accounts.role')  }}</label>
-                                        <select id="selectRole" multiple
-                                                data-hs-select='{
+                                <div id="selectRole-div" class="relative hidden"
+                                     data-account-email="{{ $account->email }}"
+                                     data-old-roles="{{ json_encode($account->roles->pluck('name')) }}"
+                                     style="width: 250px;">
+                                    <label for="selectRole"
+                                           hidden>{{ __('manage-accounts/accounts.role')  }}</label>
+                                    <select id="selectRole" multiple
+                                            data-hs-select='{
                                                     "placeholder": "{{ __('manage-accounts/accounts.multiple_select_placeholder') }}",
                                                     "toggleTag": "<button type=\"button\"></button>",
                                                     "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative z-0 py-3 px-4 pe-9 flex text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm focus:border-blue-500 focus:ring-blue-500 before:absolute before:inset-0 before:z-[1] dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600",
@@ -100,16 +100,15 @@
                                                     "optionClasses": "py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-none focus:bg-gray-100 dark:bg-slate-900 dark:hover:bg-slate-800 dark:text-gray-200 dark:focus:bg-slate-800",
                                                     "optionTemplate": "<div class=\"flex justify-between items-center w-full\"><span data-title></span><span class=\"hidden hs-selected:block\"><svg class=\"flex-shrink-0 size-3.5 text-blue-600 dark:text-blue-500\" xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div>"
                                                     }' class="hidden">
-                                            @foreach($roles as $role)
-                                                <option value="{{ $role->name }}"
-                                                        data-translated-name="{{ __('manage-accounts/roles.' . $role->name) }}" {{ in_array($role->name, $account->roles->pluck('name')->toArray()) ? 'selected' : '' }}>
-                                                    {{ __('manage-accounts/roles.' . $role->name) }}
-                                                </option>
-                                            @endforeach
-                                        </select>
-                                    </div>
-                                </div>-->
-                                <div class="text-blue-600">
+                                        @foreach($roles as $role)
+                                            <option value="{{ $role->name }}"
+                                                    data-translated-name="{{ __('manage-accounts/roles.' . $role->name) }}" {{ in_array($role->name, $account->roles->pluck('name')->toArray()) ? 'selected' : '' }}>
+                                                {{ __('manage-accounts/roles.' . $role->name) }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div id="addRoleButton" class="text-blue-600 h-10">
                                     <div class="hs-tooltip inline-block">
                                         <button type="button" class="hs-tooltip-toggle">
                                             <svg width="40px" height="40px" viewBox="0 0 24 24" fill="none"

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -73,7 +73,7 @@
                             @endif
                         </th>
                         <th scope="col"
-                            class="w-1/5 px-6 py-3 text-start text-xs font-medium text-gray-500 uppercase">
+                            class="w-1/5 px-6 py-3 text-xs font-medium text-gray-500 uppercase text-end">
                             {{ __('manage-accounts/accounts.role') }}
                         </th>
                     </tr>

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -85,10 +85,9 @@
                                 {{ $account['email'] }}
                             </td>
                             <td class="flex items-center justify-end px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
-                                <div id="selectRole-div" class="relative hidden"
+                                <div id="selectRole-div" class="relative w-[250px] hidden"
                                      data-account-email="{{ $account->email }}"
-                                     data-old-roles="{{ json_encode($account->roles->pluck('name')) }}"
-                                     style="width: 250px;">
+                                     data-old-roles="{{ json_encode($account->roles->pluck('name')) }}">
                                     <label for="selectRole"
                                            hidden>{{ __('manage-accounts/accounts.role')  }}</label>
                                     <select id="selectRole" multiple

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -105,7 +105,7 @@
                                         peer-[:not(:placeholder-shown)]:-translate-y-1.5
                                         peer-[:not(:placeholder-shown)]:text-gray-500 dark:peer-[:not(:placeholder-shown)]:text-gray-500 dark:text-gray-500">Bevers</label>
                                 </div>
-                                <div id="selectRoleContainer" class="flex flex-row hidden">
+                                <div id="selectRoleContainer" class="flex flex-row gap-2 hidden">
                                     <div id="selectRole-wrapper" class="relative w-[250px]"
                                          data-account-email="{{ $account->email }}"
                                          data-old-roles="{{ json_encode($account->roles->pluck('name')) }}">
@@ -115,7 +115,7 @@
                                                 data-hs-select='{
                                                     "placeholder": "{{ __('manage-accounts/accounts.multiple_select_placeholder') }}",
                                                     "toggleTag": "<button type=\"button\"></button>",
-                                                    "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative z-0 py-3 px-4 pe-9 flex text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm focus:border-blue-500 focus:ring-blue-500 before:absolute before:inset-0 before:z-[1] dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600",
+                                                    "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 h-[54px] relative items-center z-0 py-3 px-4 pe-9 flex text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm focus:border-blue-500 focus:ring-blue-500 before:absolute before:inset-0 before:z-[1] dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600",
                                                     "dropdownClasses": "z-50 mt-2 w-full max-h-72 p-1 space-y-0.5 bg-white border border-gray-200 rounded-lg overflow-hidden overflow-y-auto dark:bg-slate-900 dark:border-gray-700",
                                                     "optionClasses": "py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-none focus:bg-gray-100 dark:bg-slate-900 dark:hover:bg-slate-800 dark:text-gray-200 dark:focus:bg-slate-800",
                                                     "optionTemplate": "<div class=\"flex justify-between items-center w-full\"><span data-title></span><span class=\"hidden hs-selected:block\"><svg class=\"flex-shrink-0 size-3.5 text-blue-600 dark:text-blue-500\" xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div>"
@@ -128,21 +128,19 @@
                                             @endforeach
                                         </select>
                                     </div>
-                                    <div id="cancelButton" class="text-red-600 h-[46px]">
-                                        <button class="items-center h-[46px]">
-                                            <svg width="46px" height="46px" viewBox="0 0 24 24" fill="none"
-                                                 xmlns="http://www.w3.org/2000/svg" transform="rotate(45)">
-                                                <path fill-rule="evenodd" clip-rule="evenodd"
-                                                      d="M12 2C12.5523 2 13 2.44772 13 3V11H21C21.5523 11 22 11.4477 22 12C22 12.5523 21.5523 13 21 13H13V21C13 21.5523 12.5523 22 12 22C11.4477 22 11 21.5523 11 21V13H3C2.44772 13 2 12.5523 2 12C2 11.4477 2.44772 11 3 11H11V3C11 2.44772 11.4477 2 12 2Z"
-                                                      fill="currentColor"/>
+                                    <div id="cancelButton" class="text-red-600 h-[54px]">
+                                        <button class="items-center h-[54px]">
+                                            <svg class="svg-icon" width="54px" height="54px" viewBox="0 0 1024 1024" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                                <path d="M810.66 170.66q18.33 0 30.49 12.17t12.17 30.49q0 18-12.33 30.33L572.34 512l268.81 268.34q12.33 12.33 12.33 30.33 0 18.33-12.17 30.49t-30.49 12.17q-18 0-30.33-12.33L512 572.34 243.66 841.15q-12.33 12.33-30.33 12.33-18.33 0-30.49-12.17t-12.17-30.49q0-18 12.33-30.33L451.66 512 182.99 243.66q-12.33-12.33-12.33-30.33 0-18.33 12.17-30.49t30.49-12.17q18 0 30.33 12.33L512 451.66 780.34 182.99q12.33-12.33 30.33-12.33z"/>
                                             </svg>
+
                                         </button>
                                     </div>
                                 </div>
-                                <div id="addRoleButton" class="text-blue-600 h-[46px]">
-                                    <div class="hs-tooltip inline-block h-[46px]">
+                                <div id="addRoleButton" class="text-blue-600 h-[54px]">
+                                    <div class="hs-tooltip inline-block h-[54px]">
                                         <button type="button" class="hs-tooltip-toggle items-center">
-                                            <svg width="46px" height="46px" viewBox="0 0 24 24" fill="none"
+                                            <svg width="54px" height="54px" viewBox="0 0 24 24" fill="none"
                                                  xmlns="http://www.w3.org/2000/svg">
                                                 <path fill-rule="evenodd" clip-rule="evenodd"
                                                       d="M12 2C12.5523 2 13 2.44772 13 3V11H21C21.5523 11 22 11.4477 22 12C22 12.5523 21.5523 13 21 13H13V21C13 21.5523 12.5523 22 12 22C11.4477 22 11 21.5523 11 21V13H3C2.44772 13 2 12.5523 2 12C2 11.4477 2.44772 11 3 11H11V3C11 2.44772 11.4477 2 12 2Z"

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -85,13 +85,14 @@
                                 {{ $account['email'] }}
                             </td>
                             <td class="flex items-center justify-end px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
-                                <div id="selectRole-div" class="relative w-[250px] hidden"
-                                     data-account-email="{{ $account->email }}"
-                                     data-old-roles="{{ json_encode($account->roles->pluck('name')) }}">
-                                    <label for="selectRole"
-                                           hidden>{{ __('manage-accounts/accounts.role')  }}</label>
-                                    <select id="selectRole" multiple
-                                            data-hs-select='{
+                                <div id="selectRoleContainer" class="flex flex-row hidden">
+                                    <div id="selectRole-wrapper" class="relative w-[250px]"
+                                         data-account-email="{{ $account->email }}"
+                                         data-old-roles="{{ json_encode($account->roles->pluck('name')) }}">
+                                        <label for="selectRole"
+                                               hidden>{{ __('manage-accounts/accounts.role')  }}</label>
+                                        <select id="selectRole" multiple
+                                                data-hs-select='{
                                                     "placeholder": "{{ __('manage-accounts/accounts.multiple_select_placeholder') }}",
                                                     "toggleTag": "<button type=\"button\"></button>",
                                                     "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative z-0 py-3 px-4 pe-9 flex text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm focus:border-blue-500 focus:ring-blue-500 before:absolute before:inset-0 before:z-[1] dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600",
@@ -99,13 +100,24 @@
                                                     "optionClasses": "py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-none focus:bg-gray-100 dark:bg-slate-900 dark:hover:bg-slate-800 dark:text-gray-200 dark:focus:bg-slate-800",
                                                     "optionTemplate": "<div class=\"flex justify-between items-center w-full\"><span data-title></span><span class=\"hidden hs-selected:block\"><svg class=\"flex-shrink-0 size-3.5 text-blue-600 dark:text-blue-500\" xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div>"
                                                     }' class="hidden">
-                                        @foreach($roles as $role)
-                                            <option value="{{ $role->name }}"
-                                                    data-translated-name="{{ __('manage-accounts/roles.' . $role->name) }}" {{ in_array($role->name, $account->roles->pluck('name')->toArray()) ? 'selected' : '' }}>
-                                                {{ __('manage-accounts/roles.' . $role->name) }}
-                                            </option>
-                                        @endforeach
-                                    </select>
+                                            @foreach($roles as $role)
+                                                <option value="{{ $role->name }}"
+                                                        data-translated-name="{{ __('manage-accounts/roles.' . $role->name) }}" {{ in_array($role->name, $account->roles->pluck('name')->toArray()) ? 'selected' : '' }}>
+                                                    {{ __('manage-accounts/roles.' . $role->name) }}
+                                                </option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                    <div id="cancelButton" class="text-red-600 h-[46px]">
+                                        <button class="items-center h-[46px]">
+                                            <svg width="46px" height="46px" viewBox="0 0 24 24" fill="none"
+                                                 xmlns="http://www.w3.org/2000/svg" transform="rotate(45)">
+                                                <path fill-rule="evenodd" clip-rule="evenodd"
+                                                      d="M12 2C12.5523 2 13 2.44772 13 3V11H21C21.5523 11 22 11.4477 22 12C22 12.5523 21.5523 13 21 13H13V21C13 21.5523 12.5523 22 12 22C11.4477 22 11 21.5523 11 21V13H3C2.44772 13 2 12.5523 2 12C2 11.4477 2.44772 11 3 11H11V3C11 2.44772 11.4477 2 12 2Z"
+                                                      fill="currentColor"/>
+                                            </svg>
+                                        </button>
+                                    </div>
                                 </div>
                                 <div id="addRoleButton" class="text-blue-600 h-[46px]">
                                     <div class="hs-tooltip inline-block h-[46px]">

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -15,7 +15,8 @@
     <div class="flex flex-col">
         <div class="p-1.5 min-w-full inline-block align-middle">
             <form action="{{ route('manage.accounts.filter') }}" method="GET">
-                <div class="flex space-y-2 items-start pb-4 flex-col  sm:flex-row sm:items-center sm:space-x-4 sm:space-y-0">
+                <div
+                    class="flex space-y-2 items-start pb-4 flex-col  sm:flex-row sm:items-center sm:space-x-4 sm:space-y-0">
                     <x-search-bar search="{{ $search }}"
                                   placeholder="{{ __('manage-accounts/accounts.search_placeholder') }}"/>
 
@@ -45,27 +46,27 @@
                                 @if (Request::get('direction') == 'desc')
                                     <span>
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                             stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                         <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+                                              d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
                                         </svg>
                                     </span>
                                 @else
                                     <span>
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                             stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                         <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="m4.5 15.75 7.5-7.5 7.5 7.5"/>
+                                              d="m4.5 15.75 7.5-7.5 7.5 7.5"/>
                                         </svg>
                                     </span>
                                 @endif
                             @else
                                 <span>
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                    stroke-width="1.5"
-                                    stroke="currentColor" class="w-4 h-4">
+                                     stroke-width="1.5"
+                                     stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round"
-                                    d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"/>
+                                      d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"/>
                                 </svg>
                             </span>
                             @endif
@@ -82,14 +83,16 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200">
                                 {{ $account['email'] }}
                             </td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
-                                <div id="selectRole-div" class="relative"
-                                    data-account-email="{{ $account->email }}"
-                                    data-old-roles="{{ json_encode($account->roles->pluck('name')) }}"
-                                    style="width: 250px;">
-                                    <label for="selectRole" hidden>{{ __('manage-accounts/accounts.role')  }}</label>
-                                    <select id="selectRole" multiple
-                                            data-hs-select='{
+                            <td class="flex items-center justify-end px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
+                                <!--<div id="role-modal" class="">
+                                    <div id="selectRole-div" class="relative"
+                                         data-account-email="{{ $account->email }}"
+                                         data-old-roles="{{ json_encode($account->roles->pluck('name')) }}"
+                                         style="width: 250px;">
+                                        <label for="selectRole"
+                                               hidden>{{ __('manage-accounts/accounts.role')  }}</label>
+                                        <select id="selectRole" multiple
+                                                data-hs-select='{
                                                     "placeholder": "{{ __('manage-accounts/accounts.multiple_select_placeholder') }}",
                                                     "toggleTag": "<button type=\"button\"></button>",
                                                     "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative z-0 py-3 px-4 pe-9 flex text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm focus:border-blue-500 focus:ring-blue-500 before:absolute before:inset-0 before:z-[1] dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600",
@@ -97,13 +100,30 @@
                                                     "optionClasses": "py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-none focus:bg-gray-100 dark:bg-slate-900 dark:hover:bg-slate-800 dark:text-gray-200 dark:focus:bg-slate-800",
                                                     "optionTemplate": "<div class=\"flex justify-between items-center w-full\"><span data-title></span><span class=\"hidden hs-selected:block\"><svg class=\"flex-shrink-0 size-3.5 text-blue-600 dark:text-blue-500\" xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div>"
                                                     }' class="hidden">
-                                        @foreach($roles as $role)
-                                            <option value="{{ $role->name }}"
-                                                    data-translated-name="{{ __('manage-accounts/roles.' . $role->name) }}" {{ in_array($role->name, $account->roles->pluck('name')->toArray()) ? 'selected' : '' }}>
-                                                {{ __('manage-accounts/roles.' . $role->name) }}
-                                            </option>
-                                        @endforeach
-                                    </select>
+                                            @foreach($roles as $role)
+                                                <option value="{{ $role->name }}"
+                                                        data-translated-name="{{ __('manage-accounts/roles.' . $role->name) }}" {{ in_array($role->name, $account->roles->pluck('name')->toArray()) ? 'selected' : '' }}>
+                                                    {{ __('manage-accounts/roles.' . $role->name) }}
+                                                </option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>-->
+                                <div class="text-blue-600">
+                                    <div class="hs-tooltip inline-block">
+                                        <button type="button" class="hs-tooltip-toggle">
+                                            <svg width="40px" height="40px" viewBox="0 0 24 24" fill="none"
+                                                 xmlns="http://www.w3.org/2000/svg">
+                                                <path fill-rule="evenodd" clip-rule="evenodd"
+                                                      d="M12 2C12.5523 2 13 2.44772 13 3V11H21C21.5523 11 22 11.4477 22 12C22 12.5523 21.5523 13 21 13H13V21C13 21.5523 12.5523 22 12 22C11.4477 22 11 21.5523 11 21V13H3C2.44772 13 2 12.5523 2 12C2 11.4477 2.44772 11 3 11H11V3C11 2.44772 11.4477 2 12 2Z"
+                                                      fill="currentColor"/>
+                                            </svg>
+                                            <!-- TODO: add localisation when done -->
+                                            <span
+                                                class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 transition-opacity inline-block absolute invisible z-10 py-1 px-2 bg-gray-900 text-xs font-medium text-white rounded shadow-sm dark:bg-neutral-700"
+                                                role="tooltip">Rol toevoegen</span>
+                                        </button>
+                                    </div>
                                 </div>
                             </td>
                         </tr>

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -84,7 +84,27 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200">
                                 {{ $account['email'] }}
                             </td>
-                            <td class="flex items-center justify-end px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
+                            <td class="flex items-center gap-4 justify-end px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
+                                <div class="relative">
+                                    <select id="subroleSelect{{ $account->id }}" class="peer p-4 pe-9 block w-[150px] border-gray-200 rounded-lg text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-slate-900 dark:border-slate-700 dark:text-gray-400 dark:focus:ring-neutral-600
+                                        focus:pt-6
+                                        focus:pb-2
+                                        [&:not(:placeholder-shown)]:pt-6
+                                        [&:not(:placeholder-shown)]:pb-2
+                                        autofill:pt-6
+                                        autofill:pb-2">
+                                        <option>A</option>
+                                        <option>B</option>
+                                        <option>C</option>
+                                    </select>
+                                    <label for="subroleSelect{{ $account->id }}" class="absolute top-0 start-0 p-4 h-full truncate pointer-events-none transition ease-in-out duration-100 border border-transparent peer-disabled:opacity-50 peer-disabled:pointer-events-none
+                                        peer-focus:text-xs
+                                        peer-focus:-translate-y-1.5
+                                        peer-focus:text-gray-500 dark:peer-focus:text-neutral-500
+                                        peer-[:not(:placeholder-shown)]:text-xs
+                                        peer-[:not(:placeholder-shown)]:-translate-y-1.5
+                                        peer-[:not(:placeholder-shown)]:text-gray-500 dark:peer-[:not(:placeholder-shown)]:text-gray-500 dark:text-gray-500">Bevers</label>
+                                </div>
                                 <div id="selectRoleContainer" class="flex flex-row hidden">
                                     <div id="selectRole-wrapper" class="relative w-[250px]"
                                          data-account-email="{{ $account->email }}"

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -84,7 +84,7 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200">
                                 {{ $account['email'] }}
                             </td>
-                            <td class="flex items-center gap-4 justify-end px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
+                            <td class="flex items-center gap-2 justify-end px-6 py-4 whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">
                                 <div class="relative">
                                     <select id="subroleSelect{{ $account->id }}" class="peer p-4 pe-9 block w-[150px] border-gray-200 rounded-lg text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-slate-900 dark:border-slate-700 dark:text-gray-400 dark:focus:ring-neutral-600
                                         focus:pt-6
@@ -105,7 +105,7 @@
                                         peer-[:not(:placeholder-shown)]:-translate-y-1.5
                                         peer-[:not(:placeholder-shown)]:text-gray-500 dark:peer-[:not(:placeholder-shown)]:text-gray-500 dark:text-gray-500">Bevers</label>
                                 </div>
-                                <div id="selectRoleContainer" class="flex flex-row gap-2 hidden">
+                                <div id="selectRoleContainer" class="flex flex-row gap-2 hidden items-center">
                                     <div id="selectRole-wrapper" class="relative w-[250px]"
                                          data-account-email="{{ $account->email }}"
                                          data-old-roles="{{ json_encode($account->roles->pluck('name')) }}">
@@ -128,19 +128,19 @@
                                             @endforeach
                                         </select>
                                     </div>
-                                    <div id="cancelButton" class="text-red-600 h-[54px]">
-                                        <button class="items-center h-[54px]">
-                                            <svg class="svg-icon" width="54px" height="54px" viewBox="0 0 1024 1024" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                    <div id="cancelButton" class="text-red-600 h-[35px]">
+                                        <button class="items-center h-[35px]">
+                                            <svg class="svg-icon" width="35px" height="35px" viewBox="0 0 1024 1024" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                                                 <path d="M810.66 170.66q18.33 0 30.49 12.17t12.17 30.49q0 18-12.33 30.33L572.34 512l268.81 268.34q12.33 12.33 12.33 30.33 0 18.33-12.17 30.49t-30.49 12.17q-18 0-30.33-12.33L512 572.34 243.66 841.15q-12.33 12.33-30.33 12.33-18.33 0-30.49-12.17t-12.17-30.49q0-18 12.33-30.33L451.66 512 182.99 243.66q-12.33-12.33-12.33-30.33 0-18.33 12.17-30.49t30.49-12.17q18 0 30.33 12.33L512 451.66 780.34 182.99q12.33-12.33 30.33-12.33z"/>
                                             </svg>
 
                                         </button>
                                     </div>
                                 </div>
-                                <div id="addRoleButton" class="text-blue-600 h-[54px]">
-                                    <div class="hs-tooltip inline-block h-[54px]">
+                                <div id="addRoleButton" class="text-blue-600 h-[35px]">
+                                    <div class="hs-tooltip inline-block h-[35px]">
                                         <button type="button" class="hs-tooltip-toggle items-center">
-                                            <svg width="54px" height="54px" viewBox="0 0 24 24" fill="none"
+                                            <svg width="35px" height="35px" viewBox="0 0 24 24" fill="none"
                                                  xmlns="http://www.w3.org/2000/svg">
                                                 <path fill-rule="evenodd" clip-rule="evenodd"
                                                       d="M12 2C12.5523 2 13 2.44772 13 3V11H21C21.5523 11 22 11.4477 22 12C22 12.5523 21.5523 13 21 13H13V21C13 21.5523 12.5523 22 12 22C11.4477 22 11 21.5523 11 21V13H3C2.44772 13 2 12.5523 2 12C2 11.4477 2.44772 11 3 11H11V3C11 2.44772 11.4477 2 12 2Z"

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -149,7 +149,7 @@
                                             <!-- TODO: add localisation when done -->
                                             <span
                                                 class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 transition-opacity inline-block absolute invisible z-10 py-1 px-2 bg-gray-900 text-xs font-medium text-white rounded shadow-sm dark:bg-neutral-700"
-                                                role="tooltip">Rol toevoegen</span>
+                                                role="tooltip">{{ __('manage-accounts/accounts.add-role') }}</span>
                                         </button>
                                     </div>
                                 </div>

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -108,10 +108,10 @@
                                         @endforeach
                                     </select>
                                 </div>
-                                <div id="addRoleButton" class="text-blue-600 h-10">
-                                    <div class="hs-tooltip inline-block">
-                                        <button type="button" class="hs-tooltip-toggle">
-                                            <svg width="40px" height="40px" viewBox="0 0 24 24" fill="none"
+                                <div id="addRoleButton" class="text-blue-600 h-[46px]">
+                                    <div class="hs-tooltip inline-block h-[46px]">
+                                        <button type="button" class="hs-tooltip-toggle items-center">
+                                            <svg width="46px" height="46px" viewBox="0 0 24 24" fill="none"
                                                  xmlns="http://www.w3.org/2000/svg">
                                                 <path fill-rule="evenodd" clip-rule="evenodd"
                                                       d="M12 2C12.5523 2 13 2.44772 13 3V11H21C21.5523 11 22 11.4477 22 12C22 12.5523 21.5523 13 21 13H13V21C13 21.5523 12.5523 22 12 22C11.4477 22 11 21.5523 11 21V13H3C2.44772 13 2 12.5523 2 12C2 11.4477 2.44772 11 3 11H11V3C11 2.44772 11.4477 2 12 2Z"


### PR DESCRIPTION
_Dit is alleen de frontend, dit hoort niet functioneel te zijn._

Er is een plusje toegevoegd, met tooltip die aangeeft wat het doet, om rollen toe te voegen (momenteel werkt het hetzelfde als voorheen). Als daarop geklikt wordt verschijnt de oude multiple select met een kruisje, zodat de select ook weer weg te klikken is.

Het plusje is groter dan op het originele design. Dit wegens alignment/shifting problemen, maar als dit echt niet mooi is kan ik er nog verder naar kijken.

Ook staat de styling van de subrol dropdowns erin. Momenteel staat die onder elk account, maar dat wordt nog aangepast zodra ik begin met de backend. Dit is een normale select, omdat ik anders dat label niet in de dropdown kreeg.