### PR TITLE
refactor(toegankelijkheid): feedback implemented

### DIFF
--- a/resources/views/orders/groups.blade.php
+++ b/resources/views/orders/groups.blade.php
@@ -23,8 +23,6 @@
                 <div class="image">
                     <img src="{{ asset($group->image_url) }}" alt="{{ __('orders/orders.accessibility-group-image') }} {{ $group->name }} {{ __('orders/orders.group') }}">
                 </div>
-
-                <p class="group-name dark:text-white">{{ $group->name }}</p>
             </a>
             @endforeach
         </div>

--- a/resources/views/orders/product.blade.php
+++ b/resources/views/orders/product.blade.php
@@ -62,6 +62,7 @@
                 <div class="actions">
                     @if (count($productSizes) > 1)
                     <div class="relative">
+                        <label for="product-sizes" class="hidden">{{ __('orders/orders.product') }} {{ __('orders/orders.size') }}</label>
                         <select id="product-sizes" name="product-sizes" class="peer p-4 pe-9 block w-full border-gray-200 rounded-lg text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:ring-gray-600
                         focus:pt-6
                         focus:pb-2
@@ -75,14 +76,14 @@
                             @endforeach
                         </select>
 
-                        <label for="product-sizes"
+                        <p for="product-sizes"
                         class="absolute top-0 start-0 p-4 h-full truncate pointer-events-none transition ease-in-out duration-100 border border-transparent dark:text-white peer-disabled:opacity-50 peer-disabled:pointer-events-none
                         peer-focus:text-xs
                         peer-focus:-translate-y-1.5
                         peer-focus:text-gray-500
                         peer-[:not(:placeholder-shown)]:text-xs
                         peer-[:not(:placeholder-shown)]:-translate-y-1.5
-                        peer-[:not(:placeholder-shown)]:text-gray-500">{{ __('orders/orders.size') }}</label>
+                        peer-[:not(:placeholder-shown)]:text-gray-500">{{ __('orders/orders.size') }}</p>
                     </div>
                     @endif
 

--- a/resources/views/orders/shoppingcart.blade.php
+++ b/resources/views/orders/shoppingcart.blade.php
@@ -35,7 +35,7 @@
                             id="product-{{ $product->product_id }}size-{{ $product->product_size_id }}">
                             <div class="split">
                                 <div class="image">
-                                    <img class="product-image" src="{{ $product->image_path }}" alt="{{$product}}">
+                                    <img class="product-image" src="{{ $product->image_path }}" alt="{{ $product->name }}">
                                 </div>
                                 <div>
                                     <div>
@@ -117,7 +117,7 @@
                 <div class="bg-white rounded-xl shadow p-4 sm:p-7 dark:bg-slate-900">
                     <div class="order-data">
                         <h2 class="text-4xl font-extrabold dark:text-white">{{ __('orders/orders.shoppingcart-order') }}</h2>
-                        <p class="dark:text-white">{{ __('orders/orders.order-products') }}: (<span
+                        <p class="dark:text-white">{{ __('orders/orders.order-products') }} (<span
                                 id="productCount">{{ $prices->amount }}</span>)</p>
 
                         <div class="order-total">


### PR DESCRIPTION
Het enige wat "fout" gaat zijn de product groepen plaatjes omdat die screenreader alles wat in een link zit, ziet als een losse link. De optie zou zijn om de tekst niet klikbaar te maken.