### PR TITLE
feat(roles): backend save function + tests + filter repair

### DIFF
--- a/app/Http/Controllers/AccountsController.php
+++ b/app/Http/Controllers/AccountsController.php
@@ -144,7 +144,8 @@ class AccountsController extends Controller
                         $user->assignRole($teamleaderRole);
                     }
 
-                    $role = Role::firstOrCreate(["name" => $newRole]);
+                    $role = Role::where('id', $newRole)->first();
+
                     $user->assignRole($role);
                 }
             }

--- a/app/Http/Controllers/AccountsController.php
+++ b/app/Http/Controllers/AccountsController.php
@@ -30,6 +30,9 @@ class AccountsController extends Controller
             ]);
     }
 
+    /*
+     * Is used to send data to JS files without exposing the return data
+     */
     public function getData(Request $request)
     {
         if ($request->header('X-Requested-With') === 'XMLHttpRequest') {

--- a/database/seeders/GroupSeeder.php
+++ b/database/seeders/GroupSeeder.php
@@ -65,7 +65,7 @@ class GroupSeeder extends Seeder
             "name" => "Leiders",
             "min_age" => "1",
             "max_age" => "99",
-            "image_url" => "/images/groups/leiders,png",
+            "image_url" => "/images/groups/leiders.png",
             "size_id" => "7"
         ]);
     }

--- a/public/js/manage-accounts/saveroles.js
+++ b/public/js/manage-accounts/saveroles.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const saveButton = document.getElementById('saveBtn');
             if (saveButton) {
                 saveButton.addEventListener('click', function () {
-                    if (changedAccountsInfo.length > 0) {
+                    if (changedAccountsInfo.innerHTML.trim().length > 0) {
                         confirmModal.classList.remove('hidden');
                     } else {
                         createToast('warning', langNoChanges);
@@ -42,6 +42,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             if (confirmModalBtn) {
                 confirmModalBtn.addEventListener('click', function () {
+                    submitForm();
                     confirmModal.classList.add('hidden');
                 });
             }
@@ -225,6 +226,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 });
 
                 return selectedRoles;
+            }
+
+            function submitForm() {
+                const savedRoleChanges = JSON.parse(localStorage.getItem('roleChanges')) || [];
+                document.getElementById('userRoles').value = JSON.stringify(savedRoleChanges);
+                document.getElementById('updateRoleForm').submit();
             }
         })
         .catch(error => console.error(error))

--- a/resources/views/admin/accounts.blade.php
+++ b/resources/views/admin/accounts.blade.php
@@ -33,7 +33,7 @@
                         </a>
                     </div>
                     <!-- TODO: LOCALIZATION -->
-                    <button type="button" onclick="resetLocalStorage(); return false;"
+                    <button id="resetButton" type="button" onclick="resetLocalStorage(); return false;"
                             class="py-3 px-4 mb-4 inline-flex items-center gap-x-2 text-sm font-semibold rounded-lg border border-transparent text-red-500 hover:bg-red-100 hover:text-red-800 disabled:opacity-50 disabled:pointer-events-none dark:hover:bg-red-800/30 dark:hover:text-red-400">
                         {{ __('manage-accounts/accounts.reset_changes') }}
                     </button>

--- a/tests/Browser/ManageAccountFilterTest.php
+++ b/tests/Browser/ManageAccountFilterTest.php
@@ -5,7 +5,9 @@ namespace Tests\Browser;
 use App\Enum\UserRoleEnum;
 use App\Models\User;
 use Facebook\WebDriver\WebDriverKeys;
+use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
+use Spatie\Permission\Models\Role;
 use Tests\DuskTestCase;
 
 class ManageAccountFilterTest extends DuskTestCase
@@ -82,10 +84,14 @@ class ManageAccountFilterTest extends DuskTestCase
     public function test_filtering_by_role()
     {
         $this->createUsers();
-        $this->browse(function (Browser $browser) {
+
+        $roleToFilter = Role::where('name', 'admin')->first();
+        $formattedRoleName = Str::title(str_replace('_', ' ', $roleToFilter->name));
+
+        $this->browse(function (Browser $browser) use ($formattedRoleName) {
             $browser->loginAs($this->admin)
                 ->visit(route('manage.accounts.index'))
-                ->select('filter', UserRoleEnum::localisedValue(UserRoleEnum::Admin->value))
+                ->select('filter', $formattedRoleName)
                 ->assertDontSee('aaa')
                 ->assertSee('aab');
         });

--- a/tests/Browser/ManageAccountsTest.php
+++ b/tests/Browser/ManageAccountsTest.php
@@ -81,7 +81,7 @@ class ManageAccountsTest extends DuskTestCase
      */
     public function testModalAppearsAfterRoleChange()
     {
-        $admin = User::factory()->create(['email' => 'role.dropdown.test']);
+        $admin = User::factory()->create(['email' => 'modal.displayed']);
         $admin->assignRole('admin');
 
         $userToEdit = User::find(1);
@@ -110,16 +110,18 @@ class ManageAccountsTest extends DuskTestCase
 
     public function testNoModalDisplayedWithNoChanges()
     {
-        $admin = User::factory()->create(['email' => 'no.model.displayed']);
+        $admin = User::factory()->create(['email' => 'no.modal.displayed']);
         $admin->assignRole('admin');
 
         $this->browse(function (Browser $browser) use ($admin) {
             $browser->loginAs($admin)
                 ->visit(route('manage.accounts.index'))
-                ->click('.saveBtn')
-                ->waitFor('.toast-warning', 10)
-                ->assertVisible('.toast-warning')
-                ->screenshot('manage-accounts/warning-toast');
+                ->pause(5000)
+                ->waitFor('#saveBtn')
+                ->assertVisible('#saveBtn')
+                ->press('#saveBtn')
+                ->waitFor('#dismiss-toast')
+                ->assertVisible('#dismiss-toast');
         });
     }
 }

--- a/tests/Browser/ManageAccountsTest.php
+++ b/tests/Browser/ManageAccountsTest.php
@@ -81,24 +81,30 @@ class ManageAccountsTest extends DuskTestCase
      */
     public function testModalAppearsAfterRoleChange()
     {
-        $admin = User::factory()->create(['email' => 'admin@test.com'])->assignRole('admin');
+        $admin = User::factory()->create(['email' => 'role.dropdown.test']);
+        $admin->assignRole('admin');
 
-        $testUser = User::factory()->create(['email' => 'aaa@a.a'])->assignRole('user');
+        $userToEdit = User::find(1);
+        $groupToSelect = Group::find(1);
 
-        $this->browse(function (Browser $browser) use ($admin, $testUser) {
+        $this->browse(function (Browser $browser) use ($admin, $userToEdit, $groupToSelect) {
             $browser->loginAs($admin)
-                ->visit(route('manage.accounts.index'))
-                ->clickLink(__('manage-accounts/accounts.email'))
-                ->click('[data-account-email="' . $testUser->email . '"]')
-                ->waitFor('#selectRole-div')
-                ->click(__('[data-value="admin"]'))
-                ->click('[data-account-email="' . $testUser->email . '"]')
+                ->visitRoute('manage.accounts.index')
+                ->pause(5000)
+                ->whenAvailable('#roleContainer' . $userToEdit->id, function ($container) {
+                    $container->click('#addRoleButton');
+                })
+                ->waitFor('#selectRole' . $userToEdit->id)
+                ->assertVisible('#selectRole' . $userToEdit->id)
+                ->select('#selectRole' . $userToEdit->id, $groupToSelect->name)
+                ->pause(5000)
+                ->within('#roleContainer' . $userToEdit->id, function ($container) use ($groupToSelect) {
+                    $container->waitFor('#subroleSelect' . $groupToSelect->name . '1')
+                        ->assertVisible('#subroleSelect' . $groupToSelect->name . '1');
+                })
+                ->waitFor('#saveBtn')
                 ->click('#saveBtn')
-                ->waitFor('.confirmModal', 10)
-                ->assertVisible('.confirmModal')
-                ->assertSee(__('manage-accounts/accounts.modal_warning_title'))
-                ->assertSee(__('manage-accounts/accounts.confirm_button'))
-                ->screenshot('manage-accounts/modal');
+                ->assertVisible('#confirmModal');
         });
     }
 

--- a/tests/Browser/ManageAccountsTest.php
+++ b/tests/Browser/ManageAccountsTest.php
@@ -29,32 +29,6 @@ class ManageAccountsTest extends DuskTestCase
         });
     }
 
-    public function testAddRoleSelect()
-    {
-        $admin = User::factory()->create(['email' => 'role.dropdown.test']);
-        $admin->assignRole('admin');
-
-        $userToEdit = User::find(1);
-        $groupToSelect = Group::find(1);
-
-        $this->browse(function (Browser $browser) use ($admin, $userToEdit, $groupToSelect) {
-            $browser->loginAs($admin)
-                ->visitRoute('manage.accounts.index')
-                ->pause(5000)
-                ->whenAvailable('#roleContainer' . $userToEdit->id, function ($container) {
-                    $container->click('#addRoleButton');
-                })
-                ->waitFor('#selectRole' . $userToEdit->id)
-                ->assertVisible('#selectRole' . $userToEdit->id)
-                ->select('#selectRole' . $userToEdit->id, $groupToSelect->name)
-                ->pause(5000)
-                ->within('#roleContainer' . $userToEdit->id, function ($container) use ($groupToSelect) {
-                    $container->waitFor('#subroleSelect' . $groupToSelect->name . '1')
-                        ->assertVisible('#subroleSelect' . $groupToSelect->name . '1');
-                });
-        });
-    }
-
     public function testExistingRoleAddsRoleSelect() {
         $admin = User::factory()->create(['email' => 'role.existing.select']);
         $admin->assignRole('admin');
@@ -74,12 +48,8 @@ class ManageAccountsTest extends DuskTestCase
                 });
         });
     }
-
-    /**
-     * @group manage
-     * @return void
-     */
-    public function testModalAppearsAfterRoleChange()
+    
+    public function testAddRoleAndShowModal()
     {
         $admin = User::factory()->create(['email' => 'modal.displayed']);
         $admin->assignRole('admin');

--- a/tests/Browser/ManageAccountsTest.php
+++ b/tests/Browser/ManageAccountsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser;
 
+use App\Models\Group;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
@@ -27,16 +28,29 @@ class ManageAccountsTest extends DuskTestCase
         });
     }
 
-    public function testRoleDropdown()
+    public function testAddRoleSelect()
     {
         $admin = User::factory()->create(['email' => 'role.dropdown.test']);
         $admin->assignRole('admin');
 
-        $this->browse(function (Browser $browser) use ($admin) {
+        $userToEdit = User::find(1);
+        $groupToSelect = Group::find(1);
+
+        $this->browse(function (Browser $browser) use ($admin, $userToEdit, $groupToSelect) {
             $browser->loginAs($admin)
-                ->visit(route('manage.accounts.index'))
-                ->click('#selectRole-div')
-                ->assertSee(__('manage-accounts/roles.admin'));
+                ->visitRoute('manage.accounts.index')
+                ->pause(5000)
+                ->whenAvailable('#roleContainer' . $userToEdit->id, function ($container) {
+                    $container->click('#addRoleButton');
+                })
+                ->waitFor('#selectRole' . $userToEdit->id)
+                ->assertVisible('#selectRole' . $userToEdit->id)
+                ->select('#selectRole' . $userToEdit->id, $groupToSelect->name)
+                ->pause(5000)
+                ->within('#roleContainer' . $userToEdit->id, function ($container) use ($groupToSelect) {
+                    $container->waitFor('#subroleSelect' . $groupToSelect->name . '1')
+                        ->assertVisible('#subroleSelect' . $groupToSelect->name . '1');
+                });
         });
     }
 

--- a/tests/Browser/ManageAccountsTest.php
+++ b/tests/Browser/ManageAccountsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Browser;
 use App\Models\Group;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Dusk\Browser;
+use Spatie\Permission\Models\Role;
 use Tests\DuskTestCase;
 use App\Models\User;
 
@@ -50,6 +51,26 @@ class ManageAccountsTest extends DuskTestCase
                 ->within('#roleContainer' . $userToEdit->id, function ($container) use ($groupToSelect) {
                     $container->waitFor('#subroleSelect' . $groupToSelect->name . '1')
                         ->assertVisible('#subroleSelect' . $groupToSelect->name . '1');
+                });
+        });
+    }
+
+    public function testExistingRoleAddsRoleSelect() {
+        $admin = User::factory()->create(['email' => 'role.existing.select']);
+        $admin->assignRole('admin');
+
+        $user = User::find(1);
+        $role = Role::find(4); // bevers_a
+        $group = Group::find($role->group_id);
+        $user->assignRole($role);
+
+        $this->browse(function (Browser $browser) use ($admin, $user, $group) {
+            $browser->loginAs($admin)
+                ->visitRoute('manage.accounts.index')
+                ->pause(5000)
+                ->within('#roleContainer' . $user->id, function ($container) use ($group) {
+                    $container->waitFor('#subroleSelect' . $group->name . '1')
+                        ->assertVisible('#subroleSelect' . $group->name . '1');
                 });
         });
     }

--- a/tests/Browser/ManageAccountsTest.php
+++ b/tests/Browser/ManageAccountsTest.php
@@ -48,7 +48,7 @@ class ManageAccountsTest extends DuskTestCase
                 });
         });
     }
-    
+
     public function testAddRoleAndShowModal()
     {
         $admin = User::factory()->create(['email' => 'modal.displayed']);
@@ -86,6 +86,9 @@ class ManageAccountsTest extends DuskTestCase
         $this->browse(function (Browser $browser) use ($admin) {
             $browser->loginAs($admin)
                 ->visit(route('manage.accounts.index'))
+                ->pause(5000)
+                ->waitFor('#resetButton')
+                ->click('#resetButton')
                 ->pause(5000)
                 ->waitFor('#saveBtn')
                 ->assertVisible('#saveBtn')

--- a/tests/Feature/ManageAccountsTest.php
+++ b/tests/Feature/ManageAccountsTest.php
@@ -31,8 +31,8 @@ class ManageAccountsTest extends TestCase
         $userRolesData = [
             [
                 'email' => $userToBeModified->email,
-                'oldRoles' => $userToBeModified->roles()->first()->name,
-                'newRoles' => ['admin'],
+                'oldRoles' => $userToBeModified->roles()->first()->id,
+                'newRoles' => [Role::where('name', 'admin')->first()->id],
             ]
         ];
 

--- a/tests/Feature/ManageAccountsTest.php
+++ b/tests/Feature/ManageAccountsTest.php
@@ -12,10 +12,6 @@ class ManageAccountsTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * A basic feature test example.
-     */
-
     public function test_can_update_roles(): void
     {
         $admin = User::factory()->create(['email' => 'admin@test.com']);


### PR DESCRIPTION
_Aangezien alle drie de taken opzich een hele kleine PR zouden vormen heb ik dit allemaal in één keer gedaan._

Het is nu mogelijk om rollen daadwerkelijk op te slaan. Deze rollen worden dan ook correct weergegeven dmv de selects na het opslaan.

Ook heb ik meteen testen geschreven, zowel browser- als featuretests, en bestaande testen heb ik gefixt zodat ze werken met de nieuwe accounts promoveren logica.

Voor het filteren; momenteel kan er gefilterd worden per rol (zoals het voorheen was, maar dan met een wat grotere selectie). De user rol staat nog wel in de selectie van de filter, maar deze levert voor nu geen resultaten op (geen accounts met user rol in deze branch).